### PR TITLE
Move caching of ConfintStore inside permute_picking.

### DIFF
--- a/scoary/permutations.py
+++ b/scoary/permutations.py
@@ -1,7 +1,8 @@
-import os
 import logging
-import pandas as pd
+import os
+
 import numpy as np
+import pandas as pd
 
 from .KeyValueStore import KeyValueStore
 from .picking import pick
@@ -39,9 +40,6 @@ class ConfintStore(KeyValueStore):
         self.con.commit()
 
 
-CONFINT_CACHE = ConfintStore(table_name='confint_cache', db_path=os.environ.get('CONFINT_DB', None))
-
-
 def create_permuted_df(labels: [str], n_positive: int, n_permut: int, random_state: int = None):
     if random_state:
         np.random.seed(random_state)
@@ -74,6 +72,9 @@ def permute_picking(
     n_reused = 0
 
     pvals = []
+    CONFINT_CACHE = ConfintStore(table_name='confint_cache',
+                                 db_path=os.environ.get('CONFINT_DB', None))
+
     for _, row in result_df.iterrows():
         label_to_gene = genes_bool_df.loc[row.Gene]
         unique_topology = tree.uniquify(label_to_gene)


### PR DESCRIPTION
Caching an SQL connection on import of scoary works fine when used as a command line tool, but not when scoary is integrated in another python application, as this can lead to the SQL object being used in a different thread than the one it was created in.

This led to issues in the webapplication into which I integrated scoary. I've actually fixed it there (see https://github.com/metagenlab/zDB/pull/101), so I do not need this fix here, but I think it might be useful if anyone else wants to integrate scoary in a python application.

To fix this I simply moved the caching into the `permute_picking` function, so the connection is renewed every time that function is called. I think that should not have any negative impact on performance.